### PR TITLE
Messenger Starter - Kris

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,14 @@ jobs:
           wait-on-timeout: 60
 
       - name: Save screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cypress-screenshots
           path: client/cypress/screenshots
 
       - name: Save videos
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cypress-videos

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,169 @@
+# Webhook Ingestion Architecture
+
+This document details the webhook ingestion architecture that we will be using for Hair Clubs.
+
+## Requirements
+---
+- Zero data loss 
+- Exactly once processing (each event handled exactly once, even if Meta retries delivery) 
+- Outbound API calls back to Meta (to fetch additional data) must respect Meta's rate limits 
+- The system needs to gracefully handle Meta being temporarily down 
+- We need to know if processing falls behind so we can intervene 
+
+## Components and Data Flow
+
+```text
+Meta Webhook
+     |
+     v
+Webhook API
+  - validate signature
+  - store raw event
+         w/ processing details
+  - dedupe by event id
+     |
+     v
+Postgres: webhook_events (which includes processing details like processed, failed, etc.)
+     |
+     v
+RabbitMQ: event_processing_queue
+     |
+     v
+Celery Worker Pool
+  - claim event
+  - call to meta if needed
+  - apply business logic
+  - mark processed
+     |
+     v
+Postgres: webhook_event processed data / status updates
+
+------
+
+Celery Worker Pool
+     |
+     v
+Meta API
+  - rate limited calls
+  - retries with backoff
+```
+
+For retrying jobs:
+
+```text
+Worker failure
+     |
+     v
+Delayed Retry (backoff)
+     |
+     v
+Worker retries but still fails after `n` tries
+     |
+     v
+Dead letter Queue
+```
+
+## Storage choices
+
+App Database
+- Stores the webhook events + processing details
+- Each of the webhook events must be uniquely identifiable using meta's generated webhook id for idempotence
+- Must store the processing details of each webhook. If the webhook has succeeded, or failed
+
+Queue
+- A job queue
+     Stores jobs that have yet to be worked on
+- A dead letter queue
+     Stores jobs that have failed after max retries
+- A retry queue
+     For jobs that have failed but have yet to hit max retries while waiting for backoff
+
+We need the queue for two things:
+- To control how much we hit the meta API. We should be able to control how much we hit our vendors so we don't hit the rate limits. Queues allow us to manage how often we hit the api.
+- To avoid losing work after ingestion. The database is the source of truth for zero data loss; the queue lets us retry and process asynchronously.
+
+Cache
+- We'll need a cache layer to cache our responses from meta, especially when we expect them to be the same.
+- For example, when we're expecting to fetch a parent object's details from multiple children, we'd want to cache that so we wont hit the API unnecessarily.
+- For retries, this might also be a good idea because failures might happen after fetching more information about a webhook event, like post details. If we store that, we can just use the cache when retrying instead of calling the meta api again, which contributes to rate limits.
+
+## Idempotency, Deduplication, Storage, and Failure modes
+
+Storing webhook events to the database immediately before acknowledging to meta that we have received it allows us to make events idempotent. Deduplication happens at the database insert, if we receive the same event, we can check the database and deduplicate these events. Adding a unique constraint in the webhook_id, or simply using the webhook_id as a primary key would enforce another layer of dedupliation. If the insert succeeds, its the first time we received this data and we can give acknowledgement to meta. If it fails, we can ackonwledge we received the data without adding it to the queue. Simple storage can help us stop redundant processing.
+
+For our failure modes:
+1. Duplicate webhook delivery
+We can receive multiple of the same event, or meta could send them multiple times, but if we've successfully added that to the database, we can be sure to not process it again.
+
+2. API crashes before storing the event
+In this scenario, the API tries as much as possible to store it to the database first for minimal failure scenarios between reception and persistence. In the case where we can't observability helps here because we can know when this fails, and we can log the payload. If it still fails before logging, we rely on meta to retry since the event failed to be acknowledged by our webhook.
+
+3. API stores the event but fails to enqueue
+We store event status to the database, so we'd know if it was ingested but not queued. A reconciler can periodically scan `received` events that were not queued and enqueue them. We can take the right action based on this.
+
+4. Worker crashes while processing
+Similar to 3, the event status is persisted in the database. If the worker crashes, we can either retry it or enqueue it again.
+
+5. Worker processes, but crashes before marking the event as processed
+It can be retried, our cache layers will work here because we'd have cached our meta calls. Even if this was not something we'd cached, a retry should be possible here. Writes should be made idempotent as well by using keyed upserts/inserts. That way we won't have multiple rows inserted to the database.
+
+6. Meta API is down or rate limited
+The worker attempts normally with exponential backoff and max retries. Jobs are moved to dead letter queue after max retries for processing again later. Ideally we'd pause processing job in the queue while we periodically poke the meta api with either health endpoints or lightweight apis to check. Once up again, we start working on the jobs.
+
+7. Invalid payloads
+Workers will retry this normally, and sent to the dead letter queue. Notes on why it failed should also be there.
+
+The webhook events should have these following statuses:
+- received
+- queued
+- processing
+- processed
+- failed
+
+While the webhook_events table should also store the following:
+- number of attempts
+- next retry
+- last error
+- payload
+- meta unique id
+- processed timestamp
+
+## Burst scenario without losing events
+
+The webhook only ingests, persists, enqueues, and then acknowledges. The webhook must never process anything else. Bursts won't affect the webhook because the API should be able to scale with traffic, and offloading heavy jobs to the queue helps keep the webhook available as much as possible. 
+
+The queue is the most critical part, since it absorbs the burst traffic. We can scale the queue as much as we want, while making sure that rate limits won't get hit. 
+
+Since the webhook only ingests and persists, we won't have that much data loss, so we'll guarantee a very high rate of webhook persistence. Observability helps us with events that fail in this critical part because we can log the event payload in case it fails between reception and persistence.
+
+## Handle meta being down for 30 minutes
+
+The best way to do this is to stop queue processing when we detect that meta is down. We'll make sure to continue poking the api with health checks or lightweight apis to see if its still down. Once up, we will continue with processing the jobs in the queue.
+
+## Observability Strategy
+
+We will observe the following metrics:
+- Events received per second: Average and Peak
+- Heatmap of times where we're most busy
+- Logging to a platform like Sentry all expected failure points + unhandled exceptions with payload, reason, and stack trace
+- How many jobs are currently queued and not processed to see bottleneck
+- Events failed per second: Average and peak
+- Failure sorted by event type
+- Queue job count per queue
+- Oldest job age / queue lag
+- Dead letter queue count
+- Meta API rate-limit responses / error rates
+
+With these observability strategies, we can safely cover all of our vulnerabilities and also study certain trends in our webhook ingestion. How often meta fails, how often do our jobs fail, what kinds of jobs fail the most, and all of the other metrics help us shift our strategy in the long run to cover for our weaknesses.
+
+## What you'd build differently if volume was 100x larger
+
+A more aggressive load balancer and horizontal scaling would be necessary.
+More instances to receive the data would be beneficial so we can keep receiving data, and since webhook ingestion is lightweight, that helps us keep instances free fast.
+
+More queue topics would also be beneficial here. Since different meta apis will have different rate limits, we can move each api type to its own queue that way we can run multiple calls at the same time.
+More queues at the processing level would also be beneficial. From ingestion, deduplication, hitting meta's endpoints, processing and persistence can be done in multiple queues so we can keep queues lightweight and we'd have less bottleneck per queue.
+
+An optimization in the database layer is also beneficial, we can partition the database (assuming we'd have millions of rows in the webhook events alone) so overhead when querying the database remains small. This would also help us with cleanup later on when needed.
+
+At 100x volume, I would consider Kafka because webhook events become a durable event stream. Kafka gives us partitioning, replay, retention, and consumer lag tracking.

--- a/bug-fix.md
+++ b/bug-fix.md
@@ -1,0 +1,130 @@
+# Bug Fix
+
+I will be detailing both bugs and how I fixed them in this document. The format is as follows: 
+
+- Initial assumptions 
+  are going to be my first assumptions on what is happening without having read the code yet.
+- Investigation
+  Live investigation notes and things I'm doing while investigating and fixing.
+
+## Bug 1 - Chat messages aren't appearing on screen
+
+### Initial Assumptions
+
+---
+
+I'm thinking this lacks optimistic updates. We're sending it to the server and persisting to the db but the UI is not optimistically updated.
+First thing to check is the function to send and what happens there.
+
+### Investigation
+
+---
+
+I need to find the method that sends the message. I checked the `handleSubmit()` method in `/client/src/components/ActiveChat/Input.js`, and my assumption is half correct.
+
+First, `postMessage` calls `saveMessage`, an async method, but we aren't awaiting it. We need to fix that.
+
+Next, Optimistic updates are being "done" but there is a problem with how this is implemented.
+
+For context:
+Home.js > ActiveChat.js > Input.js is the branch in the DOM Tree that handles the saving.
+`postMessage()` is prop drilled from home to input and is called in `handleSubmit()`.
+
+in `Home.js postMessage()`, we are calling `addMessageToConversation` which is a `useCallback` that simply does a `forEach` on `conversations`. Directly editing the `conversations` state array will not do anything since react doesn't detect changes to the reference. We need to use the `setConversations` with a new array or object reference so react detects the state change.
+
+I'm seeing that `addNewConvo()` also does the same thing, so I'm fixing this as well. 
+
+Checking further, `addMessageToConversation` is also called when we receive a message from the other user, so fixing `addMessageToConversation` fixes both sending and receiving. 
+
+Using Codex to double check if i'm missing something.
+
+### Solution:
+
+---
+
+Fix the mutation of the `conversations` state in `Home.js`. Previously `addNewConvo` and `addMessageToConversation` only used `conversations.forEach` which changes the current state, but react won't detect changes to that. Instead we changed it to `setConversations((prev) => {...})` to properly update state.
+
+To answer each question in the file:
+
+1. How I diagnosed this bug:
+
+I assumed something was wrong with optimistic updates, or maybe updating the messages in general. So i traced what we call when a message is submitted. I reached `Home.js` and the `postMessage` method in that file. There i saw that `addMessageToConversation` and `addNewConvo` were mutating the `conversations` array directly and that `saveMessage` was an async method we were calling without awaiting.
+
+1. What tools I used:
+
+This was simple enough for me to diagnose by myself quickly so I only used Codex to double check and confirm if I'm missing something after I fixed the error and tested it out.
+
+1. What the root cause was:
+
+Biggest issue: mutating `conversations` without using `setConversations`. 
+Second issue: calling `saveMessage` without awaiting it. 
+
+## Bug 2 - Messages display order is wrong
+
+### Initial Assumption
+
+---
+
+On page load, messages are ordered latest at the top, oldest at the bottom. When we receive and send a message, they are appended correctly at the bottom. This is either a bug on the server side ordering, or client side display inversion. Either way I'll be checking both. 
+
+### Investigation
+
+---
+
+I'll start investigating the server to see if we are ordering it there.
+
+Checking `server/routes/api/conversations.js`, we can see that the model message is included and ordered in DESCENDING order using the `createdAt` field. This is normally a correct mental model because if we paginate the data later on, we want to fetch the latest first, reverse the list in the frontend, and then when we scroll up we fetch the next older messages.
+
+However since this task is time-bound and making the chat screen only load when needed is not part of the scope, we'll stick with fixing this.
+
+So the current descending order sorts the messages latest first and that's what we display in the frontend since `Home.js` doesn't do any re-ordering, or inversion of arrays.
+
+Current ordering:
+
+```
+latest
+latest 2
+...
+oldest
+```
+
+We need to make it so that the list returns:
+
+```
+oldest
+...
+latest 2
+latest
+```
+
+So we need to change it to `ASC` instead of `DESC`. I'm changing the include level message order to `ASC`. That didn't work. I'm checking, why and I see that the top level order is also ordering message in descending order. 
+
+I consult Codex here and they say include level orders aren't reliable. I double check with google and find multiple sources in Medium and StackOverflow talking about using top level orders instead. I change the top level order to Ascending and this works.
+
+Next problem, the preview for the latest message is now using the first message. Initial assumption again is that it gets the first message of the list as the "latest message" because that's where the latest message was initially located. We need to change it to point to the end of the array.
+
+I find for references of `latestMessageText` in both frontend and backend. The api actually sets this before returning the full json and it uses the first message: `convoJSON.latestMessageText = convoJSON.messages[0].text`
+
+I check frontend to be sure as well, but all i see are lines that change the current latestMessageText to the recently added message to the conversation. Which is correct.
+
+So I need to change `convoJSON.messages[0].text` to take the length - 1 instead of 0.
+
+## Solution:
+
+---
+
+Fix the backend ordering of the messages from Descending order to Ascending order. This fixed the display issue. This causes another issue which is the latest message was always assumed to be the first one in the array. Since the order is flipped, we need to get the last message in the array instead of the first.
+
+1. How I diagnosed this bug:
+
+I had an assumption of it being cased by either backend using the wrong order, or frontend flipping the order. I checked the API to see if the ordering was wrong and it sure was. 
+
+To note: It would be correct to use DESC if we flipped it in the frontend, and wanted to implement a paginated scrolling list that only loads a few messages at a time, but that is out of scope for now.
+
+1. What tools I used:
+
+Asked codex and google why changing the include-level order didn't work. Otherwise this was simple enough to do on my own. 
+
+1. What the root cause
+
+the API was ordering the messages in Descending order which meant first message that is displayed is the latest, instead of the oldest.

--- a/client/src/components/ActiveChat/ActiveChat.js
+++ b/client/src/components/ActiveChat/ActiveChat.js
@@ -25,13 +25,17 @@ const ActiveChat = ({
   user,
   conversations,
   activeConversationId,
+  activeOtherUserId,
   postMessage,
 }) => {
   const classes = useStyles();
 
   const conversation = conversations
     ? conversations.find(
-        (conversation) => Number(conversation.id) === Number(activeConversationId)
+        (conversation) =>
+          Number(conversation.id) === Number(activeConversationId) ||
+          (!activeConversationId &&
+            Number(conversation.otherUser.id) === Number(activeOtherUserId))
       )
     : {};
 

--- a/client/src/components/ActiveChat/ActiveChat.js
+++ b/client/src/components/ActiveChat/ActiveChat.js
@@ -8,6 +8,8 @@ const useStyles = makeStyles(() => ({
     display: "flex",
     flexGrow: 8,
     flexDirection: "column",
+    minWidth: 0,
+    minHeight: 0,
   },
   chatContainer: {
     marginLeft: 41,
@@ -15,21 +17,21 @@ const useStyles = makeStyles(() => ({
     display: "flex",
     flexDirection: "column",
     flexGrow: 1,
-    justifyContent: "space-between",
+    minHeight: 0,
   },
 }));
 
 const ActiveChat = ({
   user,
   conversations,
-  activeConversation,
+  activeConversationId,
   postMessage,
 }) => {
   const classes = useStyles();
 
   const conversation = conversations
     ? conversations.find(
-        (conversation) => conversation.otherUser.username === activeConversation
+        (conversation) => Number(conversation.id) === Number(activeConversationId)
       )
     : {};
 
@@ -52,6 +54,9 @@ const ActiveChat = ({
                   messages={conversation.messages}
                   otherUser={conversation.otherUser}
                   userId={user.id}
+                  otherUserLastReadMessageId={
+                    conversation.otherUserLastReadMessageId
+                  }
                 />
                 <Input
                   otherUser={conversation.otherUser}

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -1,18 +1,38 @@
 import React from "react";
 import { Box } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
 import { SenderBubble, OtherUserBubble } from ".";
 import moment from "moment";
 
+const useStyles = makeStyles(() => ({
+  root: {
+    flexGrow: 1,
+    minHeight: 0,
+    overflowY: "auto",
+    paddingTop: 24,
+    paddingBottom: 24,
+  },
+}));
+
 const Messages = (props) => {
-  const { messages, otherUser, userId } = props;
+  const classes = useStyles();
+  const { messages, otherUser, userId, otherUserLastReadMessageId } = props;
 
   return (
-    <Box>
+    <Box className={classes.root}>
       {messages.map((message) => {
         const time = moment(message.createdAt).format("h:mm");
 
         return message.senderId === userId ? (
-          <SenderBubble key={message.id} text={message.text} time={time} />
+          <SenderBubble
+            key={message.id}
+            text={message.text}
+            time={time}
+            otherUser={otherUser}
+            showReadAvatar={
+              Number(message.id) === Number(otherUserLastReadMessageId)
+            }
+          />
         ) : (
           <OtherUserBubble
             key={message.id}

--- a/client/src/components/ActiveChat/SenderBubble.js
+++ b/client/src/components/ActiveChat/SenderBubble.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
-import { Box, Typography } from "@material-ui/core";
+import { Avatar, Box, Typography } from "@material-ui/core";
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -25,9 +25,14 @@ const useStyles = makeStyles(() => ({
     background: "#F4F6FA",
     borderRadius: "10px 10px 0 10px",
   },
+  readAvatar: {
+    height: 18,
+    width: 18,
+    marginTop: 4,
+  },
 }));
 
-const SenderBubble = ({ time, text }) => {
+const SenderBubble = ({ time, text, otherUser, showReadAvatar }) => {
   const classes = useStyles();
 
   return (
@@ -36,6 +41,13 @@ const SenderBubble = ({ time, text }) => {
       <Box className={classes.bubble}>
         <Typography className={classes.text}>{text}</Typography>
       </Box>
+      {showReadAvatar && (
+        <Avatar
+          alt={otherUser.username}
+          src={otherUser.photoUrl}
+          className={classes.readAvatar}
+        />
+      )}
     </Box>
   );
 };

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -62,9 +62,9 @@ const Home = ({ user, logout }) => {
     });
   };
 
-  const postMessage = (body) => {
+  const postMessage = async (body) => {
     try {
-      const data = saveMessage(body);
+      const data = await saveMessage(body);
 
       if (!body.conversationId) {
         addNewConvo(body.recipientId, data.message);
@@ -80,41 +80,60 @@ const Home = ({ user, logout }) => {
 
   const addNewConvo = useCallback(
     (recipientId, message) => {
-      conversations.forEach((convo) => {
-        if (convo.otherUser.id === recipientId) {
-          convo.messages.push(message);
-          convo.latestMessageText = message.text;
-          convo.id = message.conversationId;
-        }
-      });
-      setConversations(conversations);
+      setConversations((prev) =>
+        prev.map((convo) => {
+          if (convo.otherUser.id !== recipientId) {
+            return convo;
+          }
+
+          return {
+            ...convo,
+            id: message.conversationId,
+            latestMessageText: message.text,
+            messages: [...convo.messages, message],
+          };
+        })
+      );
     },
-    [setConversations, conversations]
+    [setConversations]
   );
 
   const addMessageToConversation = useCallback(
     (data) => {
       // if sender isn't null, that means the message needs to be put in a brand new convo
       const { message, sender = null } = data;
-      if (sender !== null) {
-        const newConvo = {
-          id: message.conversationId,
-          otherUser: sender,
-          messages: [message],
-        };
-        newConvo.latestMessageText = message.text;
-        setConversations((prev) => [newConvo, ...prev]);
-      }
 
-      conversations.forEach((convo) => {
-        if (convo.id === message.conversationId) {
-          convo.messages.push(message);
-          convo.latestMessageText = message.text;
+      setConversations((prev) => {
+        const existingConvo = prev.find(
+          (convo) => convo.id === message.conversationId
+        );
+
+        if (!existingConvo && sender !== null) {
+          return [
+            {
+              id: message.conversationId,
+              otherUser: sender,
+              messages: [message],
+              latestMessageText: message.text,
+            },
+            ...prev,
+          ];
         }
+
+        return prev.map((convo) => {
+          if (convo.id !== message.conversationId) {
+            return convo;
+          }
+
+          return {
+            ...convo,
+            latestMessageText: message.text,
+            messages: [...convo.messages, message],
+          };
+        });
       });
-      setConversations(conversations);
     },
-    [setConversations, conversations]
+    [setConversations]
   );
 
   const setActiveChat = (username) => {
@@ -183,6 +202,7 @@ const Home = ({ user, logout }) => {
     const fetchConversations = async () => {
       try {
         const { data } = await axios.get("/api/conversations");
+        console.log(data)
         setConversations(data);
       } catch (error) {
         console.error(error);

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -21,6 +21,7 @@ const Home = ({ user, logout }) => {
 
   const [conversations, setConversations] = useState([]);
   const [activeConversationId, setActiveConversationId] = useState(null);
+  const [activeOtherUserId, setActiveOtherUserId] = useState(null);
 
   const classes = useStyles();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -94,8 +95,9 @@ const Home = ({ user, logout }) => {
           };
         })
       );
+      setActiveConversationId(message.conversationId);
     },
-    [setConversations]
+    [setConversations, setActiveConversationId]
   );
 
   const markMessageAsRead = useCallback(
@@ -240,6 +242,7 @@ const Home = ({ user, logout }) => {
 
   const setActiveChat = (conversation) => {
     setActiveConversationId(conversation.id || null);
+    setActiveOtherUserId(conversation.otherUser.id);
     markConversationAsRead(conversation);
   };
 
@@ -311,6 +314,7 @@ const Home = ({ user, logout }) => {
 
   useEffect(() => {
     setActiveConversationId(null);
+    setActiveOtherUserId(null);
   }, [user?.id]);
 
   useEffect(() => {
@@ -347,6 +351,7 @@ const Home = ({ user, logout }) => {
         />
         <ActiveChat
           activeConversationId={activeConversationId}
+          activeOtherUserId={activeOtherUserId}
           conversations={conversations}
           user={user}
           postMessage={postMessage}

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -20,7 +20,7 @@ const Home = ({ user, logout }) => {
   const socket = useContext(SocketContext);
 
   const [conversations, setConversations] = useState([]);
-  const [activeConversation, setActiveConversation] = useState(null);
+  const [activeConversationId, setActiveConversationId] = useState(null);
 
   const classes = useStyles();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -98,6 +98,44 @@ const Home = ({ user, logout }) => {
     [setConversations]
   );
 
+  const markMessageAsRead = useCallback(
+    async (conversationId, messageId) => {
+      if (!conversationId || !messageId || !user?.id) {
+        return;
+      }
+
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+
+      setConversations((prev) =>
+        prev.map((convo) =>
+          Number(convo.id) === Number(conversationId)
+            ? {
+                ...convo,
+                currentUserLastReadMessageId: messageId,
+              }
+            : convo
+        )
+      );
+
+      try {
+        await axios.put(`/api/conversations/${conversationId}/read`, {
+          messageId,
+        });
+
+        socket.emit("conversation-read", {
+          conversationId,
+          messageId,
+          readerId: user.id,
+        });
+      } catch (error) {
+        console.error(error);
+      }
+    },
+    [socket, user?.id]
+  );
+
   const addMessageToConversation = useCallback(
     (data) => {
       // if sender isn't null, that means the message needs to be put in a brand new convo
@@ -132,12 +170,77 @@ const Home = ({ user, logout }) => {
           };
         });
       });
+
+      if (
+        Number(message.conversationId) === Number(activeConversationId) &&
+        Number(message.senderId) !== Number(user?.id)
+      ) {
+        markMessageAsRead(message.conversationId, message.id);
+      }
+    },
+    [activeConversationId, markMessageAsRead, setConversations, user?.id]
+  );
+
+  const updateOtherUserLastReadMessage = useCallback(
+    ({ conversationId, messageId, readerId }) => {
+      setConversations((prev) =>
+        prev.map((convo) => {
+          if (
+            Number(convo.id) !== Number(conversationId) ||
+            Number(convo.otherUser.id) !== Number(readerId)
+          ) {
+            return convo;
+          }
+
+          return {
+            ...convo,
+            otherUserLastReadMessageId: messageId,
+          };
+        })
+      );
     },
     [setConversations]
   );
 
-  const setActiveChat = (username) => {
-    setActiveConversation(username);
+  const markConversationAsRead = useCallback(
+    async (conversation) => {
+      if (!conversation?.id || !user?.id) {
+        return;
+      }
+
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+
+      const latestOtherUserMessage = conversation.messages
+        .filter((message) => message.senderId !== user.id)
+        .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))[0];
+
+      if (!latestOtherUserMessage) {
+        return;
+      }
+
+      const currentReadMessage = conversation.messages.find(
+        (message) =>
+          Number(message.id) === Number(conversation.currentUserLastReadMessageId)
+      );
+
+      if (
+        currentReadMessage &&
+        new Date(currentReadMessage.createdAt) >=
+          new Date(latestOtherUserMessage.createdAt)
+      ) {
+        return;
+      }
+
+      markMessageAsRead(conversation.id, latestOtherUserMessage.id);
+    },
+    [markMessageAsRead, user?.id]
+  );
+
+  const setActiveChat = (conversation) => {
+    setActiveConversationId(conversation.id || null);
+    markConversationAsRead(conversation);
   };
 
   const addOnlineUser = useCallback((id) => {
@@ -175,6 +278,7 @@ const Home = ({ user, logout }) => {
     socket.on("add-online-user", addOnlineUser);
     socket.on("remove-offline-user", removeOfflineUser);
     socket.on("new-message", addMessageToConversation);
+    socket.on("conversation-read", updateOtherUserLastReadMessage);
 
     return () => {
       // before the component is destroyed
@@ -182,8 +286,15 @@ const Home = ({ user, logout }) => {
       socket.off("add-online-user", addOnlineUser);
       socket.off("remove-offline-user", removeOfflineUser);
       socket.off("new-message", addMessageToConversation);
+      socket.off("conversation-read", updateOtherUserLastReadMessage);
     };
-  }, [addMessageToConversation, addOnlineUser, removeOfflineUser, socket]);
+  }, [
+    addMessageToConversation,
+    addOnlineUser,
+    removeOfflineUser,
+    socket,
+    updateOtherUserLastReadMessage,
+  ]);
 
   useEffect(() => {
     // when fetching, prevent redirect
@@ -199,10 +310,13 @@ const Home = ({ user, logout }) => {
   }, [user, history, isLoggedIn]);
 
   useEffect(() => {
+    setActiveConversationId(null);
+  }, [user?.id]);
+
+  useEffect(() => {
     const fetchConversations = async () => {
       try {
         const { data } = await axios.get("/api/conversations");
-        console.log(data)
         setConversations(data);
       } catch (error) {
         console.error(error);
@@ -232,7 +346,7 @@ const Home = ({ user, logout }) => {
           setActiveChat={setActiveChat}
         />
         <ActiveChat
-          activeConversation={activeConversation}
+          activeConversationId={activeConversationId}
           conversations={conversations}
           user={user}
           postMessage={postMessage}

--- a/client/src/components/Sidebar/Chat.js
+++ b/client/src/components/Sidebar/Chat.js
@@ -22,7 +22,7 @@ const Chat = ({ conversation, setActiveChat }) => {
   const { otherUser } = conversation;
 
   const handleClick = async (conversation) => {
-    await setActiveChat(conversation.otherUser.username);
+    await setActiveChat(conversation);
   };
 
   return (

--- a/read-messages.md
+++ b/read-messages.md
@@ -1,0 +1,85 @@
+# Read Messages
+
+This document details decisions, thoughts, and trade-offs when implementing the Read status for messages.
+
+## Database design
+---
+There are a few ways to do this that come to mind immediately. Let's go through them one-by-one.
+
+### Option 1
+```
+messages
+- read: boolean
+```
+
+**Benefits:**
+This is the easiest to implement. Everything starts at false, if read, we flip the boolean to true.
+We're able to show read status immediately with this, no complications.
+
+**Drawbacks:**
+The drawback here is that we're not able to see timestamps when we want to.
+Another is this being limited to only private messaging. Group chats won't benefit from this.
+Multiple message rows will need to be updated when we read
+
+### Option 2
+```
+messages
+- read: date
+```
+
+**Benefits:**
+This is a more robust solution since we can also show when he user was able to view the message.
+However, I don't think we have any need to display seen-time. Specifications only show being able to know if the message was read or not.
+
+**Drawbacks:**
+The drawback here is that it's very limited only to private messaging like option 1.
+Multiple message rows will need to be updated when we read
+
+### Option 3
+```
+message_reads
+- messageId: message ID
+- userId: user's ID
+- readAt: date/bool
+```
+
+**Benefits:**
+This is a very future-proof way to implement reads, especially if we see ourselves opening up group chat features in the future. 
+This might be the most robust way to deal with reads in a chatting system.
+
+**Drawbacks:**
+The drawback here is that it will take way longer to implement. 
+It's robustness is also it's drawback for this current system because it's simply unnecessary to have this for a system that only provides private messaging.
+
+### Option 4
+```
+conversations
+- user1LastReadMessageId
+- user2LastReadMessageId
+```
+
+This is a conversations level approach. Every read, we'd need to update conversations.
+
+**Benefits:**
+In terms of space, this might be a better approach compared to message level fields because we're only storing a few bytes per conversation.
+Frontend will be easy to implement (`message.id === user1LastReadMessageId`)
+Allows us to update only 1 row, the conversation, instead of multiple in the case of message-level fields.
+
+**Drawbacks:**
+This also removes the ability to know when we read each message, which message-level fields and separate message_reads table offers.
+When extending to group-chat, and eventually creating message_reads, we lose the ability to add time-based information if needed.
+A lot of application-layer safeguards are needed to make sure the ids stored are from this conversation, or is the correct Id that was read. Theoretically, we could send a wrong ID here, and while easily preventable, is still an unnecessary risk to take.
+
+### Decision
+---
+**Option 4 - Conversation level fields**
+
+I eliminated Option 3 immediately due to the complexity. This level of complexity is unnecessary for a one 
+
+It was difficult to argue between Option 2 and Option 4.
+Option 2 seems like the cleanest database-level way for us to do reads. And this is true because having datetimes in each message row is intuitively a better design.
+
+However, option 4 allows us to make this feature come to life immediately. 
+
+To break it down this is the metrics i decided on:
+

--- a/read-messages.md
+++ b/read-messages.md
@@ -62,24 +62,37 @@ This is a conversations level approach. Every read, we'd need to update conversa
 
 **Benefits:**
 In terms of space, this might be a better approach compared to message level fields because we're only storing a few bytes per conversation.
-Frontend will be easy to implement (`message.id === user1LastReadMessageId`)
+Frontend will be easy to implement (`message.id === user1LastReadMessageId`) since it models what the frontend only needs: the message to display where the user has read up to
 Allows us to update only 1 row, the conversation, instead of multiple in the case of message-level fields.
 
 **Drawbacks:**
 This also removes the ability to know when we read each message, which message-level fields and separate message_reads table offers.
 When extending to group-chat, and eventually creating message_reads, we lose the ability to add time-based information if needed.
 A lot of application-layer safeguards are needed to make sure the ids stored are from this conversation, or is the correct Id that was read. Theoretically, we could send a wrong ID here, and while easily preventable, is still an unnecessary risk to take.
+This also needs messages to be ordered properly because we're relying on just storing the 'last read message id', so if the ordering is wrong, it won't work.
+
+**Safeguards neeeded**
+For the conversation-level approach, the backend needs to validate:
+- the conversation exists
+- the current user is part of the conversation
+- the message exists
+- the message belongs to that conversation
+- the message was sent by the other user, not the current user
+- the new read pointer should not move backwards to an older message
 
 ### Decision
 ---
 **Option 4 - Conversation level fields**
 
-I eliminated Option 3 immediately due to the complexity. This level of complexity is unnecessary for a one 
+I eliminated Option 3 immediately due to the complexity. This level of complexity is unnecessary for a one-on-one messaging system.
+The little difference that Option 1 and Option 2 has made it an easy contender to choose Option 2 over 1 anytime. 
 
 It was difficult to argue between Option 2 and Option 4.
 Option 2 seems like the cleanest database-level way for us to do reads. And this is true because having datetimes in each message row is intuitively a better design.
+Option 4 seems a bit difficult to argue for, but its the easiest to get going in a time-constrained feature that we have no intentions of changing in the future. So realistically, Option 4 has no problems.
 
-However, option 4 allows us to make this feature come to life immediately. 
+I chose Option 4 because the feature is not asking for per-message read history. It only needs to show the other user's avatar on the last message they have read. A conversation-level pointer directly supports that UI with less data duplication and fewer writes.
 
-To break it down this is the metrics i decided on:
+Option 2 is still a reasonable design, especially if we wanted read timestamps per message. But for this app, it would require updating multiple message rows and then calculating the latest read message anyway. Plus there was no need to show timestamps, which Option 2 is the best for. Option 4 stores that final answer directly.
 
+The drawbacks of having to set safeguards and logical layers to add are acceptable once we realize that all of the other options will also need some application-logic level safeguards to some extent as well, adding more isn't going to hurt.

--- a/server/bin/www
+++ b/server/bin/www
@@ -47,6 +47,10 @@ io.on("connection", (socket) => {
     });
   });
 
+  socket.on("conversation-read", (data) => {
+    socket.broadcast.emit("conversation-read", data);
+  });
+
   socket.on("logout", (id) => {
     if (onlineUsers.includes(id)) {
       userIndex = onlineUsers.indexOf(id);

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1,7 +1,7 @@
 const Sequelize = require("sequelize");
 
 const db = new Sequelize(
-  process.env.DATABASE_URL || "postgres://localhost:5432/messenger",
+  process.env.DATABASE_URL || "postgres://messenger:password@localhost:5432/messenger",
   {
     logging: false,
   }

--- a/server/db/models/conversation.js
+++ b/server/db/models/conversation.js
@@ -1,8 +1,16 @@
-const { Op } = require("sequelize");
+const Sequelize = require("sequelize");
+const { Op } = Sequelize;
 const db = require("../db");
 const Message = require("./message");
 
-const Conversation = db.define("conversation", {});
+const Conversation = db.define("conversation", {
+  user1LastReadMessageId: {
+    type: Sequelize.INTEGER,
+  },
+  user2LastReadMessageId: {
+    type: Sequelize.INTEGER,
+  },
+});
 
 // find conversation given two user Ids
 

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -19,9 +19,9 @@ router.get("/", async (req, res, next) => {
         },
       },
       attributes: ["id"],
-      order: [[Message, "createdAt", "DESC"]],
+      order: [[Message, "createdAt", "ASC"]],
       include: [
-        { model: Message, order: ["createdAt", "DESC"] },
+        { model: Message },
         {
           model: User,
           as: "user1",
@@ -68,7 +68,7 @@ router.get("/", async (req, res, next) => {
       }
 
       // set properties for notification count and latest message preview
-      convoJSON.latestMessageText = convoJSON.messages[0].text;
+      convoJSON.latestMessageText = convoJSON.messages[convoJSON.messages.length - 1].text;
       conversations[i] = convoJSON;
     }
 

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -141,6 +141,12 @@ router.put("/:conversationId/read", async (req, res, next) => {
       return res.status(400).json({ error: "Message is not in conversation" });
     }
 
+    if (message.senderId === req.user.id) {
+      return res
+        .status(400)
+        .json({ error: "Cannot mark your own message as read" });
+    }
+
     const readField =
       conversation.user1Id === req.user.id
         ? "user1LastReadMessageId"

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -18,8 +18,13 @@ router.get("/", async (req, res, next) => {
           user2Id: userId,
         },
       },
-      attributes: ["id"],
-      order: [[Message, "createdAt", "ASC"]],
+      attributes: [
+        "id",
+        "user1Id",
+        "user2Id",
+        "user1LastReadMessageId",
+        "user2LastReadMessageId",
+      ],
       include: [
         { model: Message },
         {
@@ -67,12 +72,101 @@ router.get("/", async (req, res, next) => {
         convoJSON.otherUser.online = false;
       }
 
+      convoJSON.messages.sort(
+        (messageA, messageB) =>
+          new Date(messageA.createdAt) - new Date(messageB.createdAt)
+      );
+
       // set properties for notification count and latest message preview
-      convoJSON.latestMessageText = convoJSON.messages[convoJSON.messages.length - 1].text;
+      convoJSON.latestMessageText =
+        convoJSON.messages[convoJSON.messages.length - 1]?.text;
+      convoJSON.currentUserLastReadMessageId =
+        convoJSON.user1Id === userId
+          ? convoJSON.user1LastReadMessageId
+          : convoJSON.user2LastReadMessageId;
+      convoJSON.otherUserLastReadMessageId =
+        convoJSON.user1Id === userId
+          ? convoJSON.user2LastReadMessageId
+          : convoJSON.user1LastReadMessageId;
       conversations[i] = convoJSON;
     }
 
+    conversations.sort((convoA, convoB) => {
+      const convoALatestMessage = convoA.messages[convoA.messages.length - 1];
+      const convoBLatestMessage = convoB.messages[convoB.messages.length - 1];
+
+      return (
+        new Date(convoBLatestMessage?.createdAt || 0) -
+        new Date(convoALatestMessage?.createdAt || 0)
+      );
+    });
+
     res.json(conversations);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// idempotently mark the current user's read position in a conversation
+router.put("/:conversationId/read", async (req, res, next) => {
+  try {
+    if (!req.user) {
+      return res.sendStatus(401);
+    }
+
+    const { conversationId } = req.params;
+    const { messageId } = req.body;
+
+    if (!messageId) {
+      return res.status(400).json({ error: "messageId is required" });
+    }
+
+    const conversation = await Conversation.findByPk(conversationId);
+
+    if (!conversation) {
+      return res.sendStatus(404);
+    }
+
+    const isConversationUser =
+      conversation.user1Id === req.user.id ||
+      conversation.user2Id === req.user.id;
+
+    if (!isConversationUser) {
+      return res.sendStatus(403);
+    }
+
+    const message = await Message.findByPk(messageId);
+
+    if (!message || message.conversationId !== conversation.id) {
+      return res.status(400).json({ error: "Message is not in conversation" });
+    }
+
+    const readField =
+      conversation.user1Id === req.user.id
+        ? "user1LastReadMessageId"
+        : "user2LastReadMessageId";
+
+    const previousReadMessageId = conversation[readField];
+
+    if (previousReadMessageId) {
+      const previousReadMessage = await Message.findByPk(previousReadMessageId);
+
+      if (
+        previousReadMessage &&
+        previousReadMessage.createdAt >= message.createdAt
+      ) {
+        return res.json({
+          conversation,
+          updated: false,
+          alreadyRead: true,
+        });
+      }
+    }
+
+    conversation[readField] = message.id;
+    await conversation.save();
+
+    res.json({ conversation, updated: true, alreadyRead: false });
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
## Description
Implemented fixes and improvements for message handling in the chat app.

Changes include:

Fixed optimistic updates when sending messages in new and existing conversations.
Fixed message ordering so chat messages display in the expected order.
Added conversation-level read tracking using user1LastReadMessageId and user2LastReadMessageId.
Added read receipt UI by showing the other user’s avatar under the last message they have read.
Added backend support for marking a conversation as read.
Added notes for webhook ingestion architecture in architecture.md.

# Notes on your approach and thought process

For the message rendering bug, I found that the frontend was mutating the existing conversations state directly with forEach and then passing the same array reference back into state. React may not detect that as a meaningful state change, so I changed the updates to use immutable state updates with setConversations.

For read receipts, I considered message-level read fields first, but chose a conversation-level read pointer because the UI only needs to know the latest message each user has read. This avoids updating multiple message rows and makes the frontend check straightforward.

I also made sure read receipts are only triggered when the user actually opens a conversation or is actively viewing the conversation when a new message arrives.
